### PR TITLE
refactor!: replace the span with SvgIcon

### DIFF
--- a/line-awesome-test/pom.xml
+++ b/line-awesome-test/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <vaadin.version>24.2.0.alpha11</vaadin.version>
+        <vaadin.version>24.2.0</vaadin.version>
         <selenium.version>4.8.1</selenium.version>
     </properties>
 

--- a/line-awesome-test/pom.xml
+++ b/line-awesome-test/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <vaadin.version>24.2-SNAPSHOT</vaadin.version>
+        <vaadin.version>24.2.0.alpha11</vaadin.version>
         <selenium.version>4.8.1</selenium.version>
     </properties>
 

--- a/line-awesome-test/pom.xml
+++ b/line-awesome-test/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <vaadin.version>24.0.0.rc1</vaadin.version>
+        <vaadin.version>24.2-SNAPSHOT</vaadin.version>
         <selenium.version>4.8.1</selenium.version>
     </properties>
 

--- a/line-awesome/pom.xml
+++ b/line-awesome/pom.xml
@@ -10,7 +10,7 @@
     <url>https://github.com/parttio/line-awesome</url>
 
     <properties>
-        <vaadin.version>24.2-SNAPSHOT</vaadin.version>
+        <vaadin.version>24.2.0.alpha11</vaadin.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -46,6 +46,18 @@
             <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
+    
+    <repositories>
+        <repository>
+            <id>vaadin-prereleases</id>
+            <url>
+                https://maven.vaadin.com/vaadin-prereleases/
+            </url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
     <issueManagement>
         <system>GitHub</system>

--- a/line-awesome/pom.xml
+++ b/line-awesome/pom.xml
@@ -10,7 +10,7 @@
     <url>https://github.com/parttio/line-awesome</url>
 
     <properties>
-        <vaadin.version>23.3.6</vaadin.version>
+        <vaadin.version>24.2-SNAPSHOT</vaadin.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/line-awesome/pom.xml
+++ b/line-awesome/pom.xml
@@ -10,7 +10,7 @@
     <url>https://github.com/parttio/line-awesome</url>
 
     <properties>
-        <vaadin.version>24.2.0.alpha11</vaadin.version>
+        <vaadin.version>24.2.0</vaadin.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -46,18 +46,6 @@
             <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
-    
-    <repositories>
-        <repository>
-            <id>vaadin-prereleases</id>
-            <url>
-                https://maven.vaadin.com/vaadin-prereleases/
-            </url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 
     <issueManagement>
         <system>GitHub</system>

--- a/line-awesome/src/main/java/org/vaadin/lineawesome/LineAwesomeIcon.java
+++ b/line-awesome/src/main/java/org/vaadin/lineawesome/LineAwesomeIcon.java
@@ -2,7 +2,6 @@ package org.vaadin.lineawesome;
 
 import java.util.Locale;
 
-import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.icon.SvgIcon;
 
 /**
@@ -1576,9 +1575,9 @@ public enum LineAwesomeIcon {
     /**
      * Creates an icon instance.
      * 
-     * @return the icon as a component
+     * @return the icon
      */
-    public Component create() {
+    public SvgIcon create() {
         return new SvgIcon("line-awesome/svg/" + getSvgName() + ".svg");
     }
 }

--- a/line-awesome/src/main/java/org/vaadin/lineawesome/LineAwesomeIcon.java
+++ b/line-awesome/src/main/java/org/vaadin/lineawesome/LineAwesomeIcon.java
@@ -3,8 +3,7 @@ package org.vaadin.lineawesome;
 import java.util.Locale;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.dom.Style;
+import com.vaadin.flow.component.icon.SvgIcon;
 
 /**
  * An integration of the https://icons8.com/line-awesome icon set.
@@ -1580,33 +1579,6 @@ public enum LineAwesomeIcon {
      * @return the icon as a component
      */
     public Component create() {
-        Span span = new Span();
-        String src = "line-awesome/svg/" + getSvgName() + ".svg";
-
-        Style style = span.getStyle();
-        style.set("--mask-image", "url('" + src + "')");
-
-        // All below should go into a CSS file
-        style.set("--mask-repeat", "no-repeat");
-        style.set("--mask-position", "50%");
-        style.set("vertical-align", "middle");
-        style.set("--_size", "var(--lumo-icon-size-m)");
-
-        style.set("mask-image", "var(--mask-image)");
-        style.set("mask-repeat", "var(--mask-repeat)");
-        style.set("mask-position", "var(--mask-position)");
-
-        style.set("width", "var(--_size)");
-        style.set("height", "var(--_size)");
-        style.set("background-color", "currentColor");
-        style.set("display", "inline-block");
-        style.set("flex", "none");
-
-        // This is for Chrome...
-        style.set("-webkit-mask-image", "var(--mask-image)");
-        style.set("-webkit-mask-repeat", "var(--mask-repeat)");
-        style.set("-webkit-mask-position", "var(--mask-position)");
-
-        return span;
+        return new SvgIcon("line-awesome/svg/" + getSvgName() + ".svg");
     }
 }

--- a/line-awesome/src/main/resources/META-INF/resources/line-awesome-icon.css
+++ b/line-awesome/src/main/resources/META-INF/resources/line-awesome-icon.css
@@ -1,5 +1,0 @@
-.la-icon {
-  width: var(--lumo-icon-size-m);
-  height: var(--lumo-icon-size-m);
-  vertical-align: middle;
-}

--- a/line-awesome/src/test/java/org/vaadin/lineawesome/LineAwesomeIconTest.java
+++ b/line-awesome/src/test/java/org/vaadin/lineawesome/LineAwesomeIconTest.java
@@ -13,4 +13,14 @@ public class LineAwesomeIconTest {
         }
 
     }
+
+    @Test
+    public void hasIconAPIs() {
+        var icon = LineAwesomeIcon.CALENDAR.create();
+        icon.setSize("100px");
+        icon.setColor("red");
+        Assertions.assertEquals("red", icon.getColor());
+        Assertions.assertEquals("100px", icon.getStyle().get("width"));
+        Assertions.assertEquals("100px", icon.getStyle().get("height"));
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
                 https://maven.vaadin.com/vaadin-prereleases/
             </url>
             <snapshots>
-                <enabled>true</enabled>
+                <enabled>false</enabled>
             </snapshots>
         </repository>
         <!-- Repository used by many Vaadin add-ons -->

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
                 https://maven.vaadin.com/vaadin-prereleases/
             </url>
             <snapshots>
-                <enabled>false</enabled>
+                <enabled>true</enabled>
             </snapshots>
         </repository>
         <!-- Repository used by many Vaadin add-ons -->


### PR DESCRIPTION
The `SvgIcon` component is available since Vaadin 24.2.

The PR also updates the return type of `create()` to enable Vaadin Icon APIs: `setSize` and `setColor`